### PR TITLE
Fixing first speaker bug when pages are revisited

### DIFF
--- a/word_count.py
+++ b/word_count.py
@@ -145,11 +145,14 @@ class Socialization_of_Emotion(object):
                 else:
                     self.df_counts.loc[currIndex, 'ID'] = currDoc
                     self.df_counts.loc[currIndex, 'PageNum'] = currPage
-                    firstSpeaker = 'parent' if currSpeaker == 'paren' else 'child'
-                    speakerChange = False
-                    self.df_counts.loc[currIndex, 'first_speaker'] = firstSpeaker
-                    self.df_counts.loc[currIndex, 'first_text'] = paragraph.text
-                    self.df_counts.loc[currIndex, 'num_parent_initial_questions'] = 0 #initialize to 0
+                    if pd.isna(self.df_counts.loc[currIndex, 'first_speaker']):
+                        firstSpeaker = 'parent' if currSpeaker == 'paren' else 'child'
+                        speakerChange = False
+                        self.df_counts.loc[currIndex, 'first_speaker'] = firstSpeaker
+                        self.df_counts.loc[currIndex, 'first_text'] = paragraph.text
+                        self.df_counts.loc[currIndex, 'num_parent_initial_questions'] = 0 #initialize to 0
+                    else:
+                        speakerChange = True
 
             if currIndex is not None:
                 # Save the transcript


### PR DESCRIPTION
Found a potential glitch with the Python Script.

`"Parent (): Uh oh. Looks like she's sad cause her kitty hurt her foot. Parent (): [Page 27] Aww look, poor kitty. And she's sad. Parent (): [Page 27] The kitty's hurt huh. Parent ():"`

For the part of the script where it's supposed to identify the first thing someone says, it's not getting it right here.
In the example I pasted above, the script is saying that "The kitty's hurt huh." Is the first thing said.
In reality, the parent and child read the page 3x (sometimes the child flips back to other pages). The script seems to be counting the first thing someone says for the last time the page is called.
If that makes sense.

```
Parent (00:01):
Yeah. Okay. I don't know if she'll sit in my lap, is that okay [inaudible]. [other dialogue].

Parent (00:09):
[Page 2] Oh, looked like she dropped her ice cream huh. Oh. Are you going to turn the pictures. What happened? Look, when she dropped her ice cream, are you just going to skim through them for me.

Child (00:42):
[Page 27] Uh-oh.

Parent (00:42):
Uh oh. Looks like she's sad cause her kitty hurt her foot.

Parent (00:47):
[Page 4] Oh, well she was mad because she can't have any cookies at some of it.

Parent (00:59):
[Page 28] Somebody else I know.

Child (01:01):
No.

Parent (01:02):
Scared of the snake.

Parent (01:04):
[Page 1] She's happy. She's happy. She got a present.

Parent (01:10):
[Page 26] Looks like he's [inaudible]. He's doing magic. And what? Huh? It's a bunny.

Child (01:24):
[Inaudible].

Parent (01:24):
Do you want to go back? Let's go back and look at them a little bit more.

Child (01:32):
[Inaudible].

Parent (01:32):
[Page 2] She spilled her ice cream cone and she's sad. I would be sad too.

Child (01:43):
[Inaudible]

Parent (01:43):
[Page 3] Look, she's scared because there's something in the closet.

Child (01:54):
[Page 15] [Inaudible].

Parent (01:54):
Uh. A stinky rat and he doesn't like it. He's stinky. Stinky trash.

Parent (02:02):
[Page 27] Aww look, poor kitty. And she's sad.

Parent (02:04):
[Page 4] Look, see. No cookies.

Parent (02:09):
[Page 28] He's scared of the snake.

Parent (02:15):
[Page 29] Oh look, there's a puppy dog. He's mad cause he chewed up the teddy bear. That sounds like something Toby our puppy would do. Huh?

Child (02:37):
[Inaudible].

Parent (02:37):
What is that? Do you see the puppy, see the puppy.

Child (02:41):
[[Sneeze]]

Parent (02:41):
Oh bless you. Bless you.

Child (02:45):
[inaudible].

Parent (02:45):
Here. Are we going to go through them again?

Child (02:45):
[inaudible].

Parent (02:48):
[Page 2] Here, look, she's sad. Huh?

Child (02:52):
[Inaudible].

Parent (02:52):
[Page 3] She's scared. [inaudible] yeah, looks like there's something scary in the closet. Careful.

Parent (03:00):
[Page 20] See, the trash is ucky. Stinky.

Parent (03:05):
[Page 27] The kitty's hurt huh.

Parent (03:08):
[Page 4] And she's mad. You're going too fast. Oh, all done. Do you want to do them again?
```

So for example, they went to Page 27 3x. The first time they read page 27, the child speaks first. However, the python script is analyzing only the 3rd time they read page 27 (the last time), and the parent happens to be the "first speaker" for that 3rd time. 